### PR TITLE
suggested fix for ctx.data bug

### DIFF
--- a/templates/handlebars/_index.js
+++ b/templates/handlebars/_index.js
@@ -142,6 +142,10 @@ module.exports = function (dest, ctx) {
    */
   ctx.data.byGroupAndType = extras.byGroupAndType(ctx.data);<% } %>
 
+  // Avoid key collision with Handlebars
+  ctx._data = ctx.data;
+  delete ctx.data;
+
   /**
    * Now we have prepared the data, we can proxy to the Themeleon
    * generated theme function.

--- a/templates/handlebars/views/index.handlebars
+++ b/templates/handlebars/views/index.handlebars
@@ -24,7 +24,7 @@
      ! types as second level (`function`, `variable` or `mixin`), items as third level.
      ! So: `groups > types > items`.
      !
-        data.byGroupAndType = {
+        _data.byGroupAndType = {
             'undefined': {
                 'function': [ ... ],
                 'mixin': [ ... ],
@@ -52,13 +52,13 @@
 
     {{!
      ! To display our items, we need to:
-     ! 1. Loop over `data.byGroupAndType` groups
+     ! 1. Loop over `_data.byGroupAndType` groups
      ! 2. Loop over types mapped to each group
      ! 3. Loop over items mapped to each type
      }}
 
-    {{! 1. Loop over the groups in `data.byGroupAndType` }}
-    {{#each data.byGroupAndType }}
+    {{! 1. Loop over the groups in `_data.byGroupAndType` }}
+    {{#each _data.byGroupAndType }}
     <section>
         {{! Retrieve group alias if any (else group name) }}
         <h1>{{ groups.[@key] }}</h1>

--- a/templates/handlebars/views/index_bare.handlebars
+++ b/templates/handlebars/views/index_bare.handlebars
@@ -20,12 +20,12 @@
 
     {{!
      ! To display our items, we need to:
-     ! 1. Loop over `data` types
+     ! 1. Loop over `_data` types
      ! 2. Loop over items mapped to each type
      }}
 
     {{! 1. Loop over the types in `data` }}
-    {{#each data }}
+    {{#each _data }}
 
       {{! If items to be displayed in type }}
       {{ if this }}


### PR DESCRIPTION
- `ctx.data` seems to get overwritten to 'true' by Handlebars compiler
- renaming it seems to work.  I'm completely open to a better name than `_data`